### PR TITLE
404 downloading config

### DIFF
--- a/bin/storm-mesos
+++ b/bin/storm-mesos
@@ -3,10 +3,12 @@
 import sys
 import os
 
-STORM_PATH = "/".join(os.path.abspath(__file__).split("/")[0:-1]) + "/storm"
+STORM_PATH = "/".join(os.path.abspath(__file__).split("/")[0:-1])
+STORM_CMD = STORM_PATH + "/storm"
 
 def nimbus():
-  os.system(STORM_PATH + " nimbus storm.mesos.MesosNimbus")
+  os.chdir(STORM_PATH + "/..")
+  os.system(STORM_CMD + " nimbus storm.mesos.MesosNimbus")
   
 def supervisor():
   os.system(STORM_PATH + " supervisor storm.mesos.MesosSupervisor")

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject storm/storm-mesos "0.9"
+(defproject storm/storm-mesos "0.9.0.1"
   :description "Storm integration with the Mesos cluster manager"
   :source-paths ["src/clj"]
   :java-source-paths ["src/jvm"]
@@ -8,7 +8,7 @@
   :dependencies [
     [org.apache.mesos/mesos "0.14.2"]
     [com.google.protobuf/protobuf-java "2.4.1"]
-    [storm "0.9.0"]
+    [storm "0.9.0.1"]
     [org.apache.commons/commons-exec "1.1"]
     [commons-lang "2.6"]
     [com.googlecode.json-simple/json-simple "1.1"]

--- a/src/jvm/storm/mesos/MesosNimbus.java
+++ b/src/jvm/storm/mesos/MesosNimbus.java
@@ -207,6 +207,9 @@ public class MesosNimbus implements INimbus {
                 finfo.setId(FrameworkID.newBuilder().setValue(id).build());
             }
 
+            _httpServer = new LocalFileServer();
+            _configUrl = _httpServer.serveDir("/conf","conf");
+            LOG.info("Started serving config dir under " + _configUrl);
 
             MesosSchedulerDriver driver =
                 new MesosSchedulerDriver(
@@ -218,10 +221,6 @@ public class MesosNimbus implements INimbus {
             LOG.info("Waiting for scheduler to initialize...");
             initter.acquire();
             LOG.info("Scheduler initialized...");
-
-            _httpServer = new LocalFileServer();
-            _configUrl = _httpServer.serveDir("/conf","conf");
-            LOG.info("Started serving config dir under " + _configUrl);
 
         } catch(IOException e) {
             throw new RuntimeException(e);

--- a/storm.yaml
+++ b/storm.yaml
@@ -12,7 +12,7 @@ nimbus.host: "localhost"
 
 # Use the public Mesosphere Storm build
 # Please note that it won't work with other distributions
-mesos.executor.uri: "http://downloads.mesosphere.io/storm/storm-mesos-0.9.tgz"
+mesos.executor.uri: "http://downloads.mesosphere.io/storm/storm-mesos-0.9.0.1.tgz"
 
 # Use Netty to avoid ZMQ dependencies
 storm.messaging.transport: "backtype.storm.messaging.netty.Context"


### PR DESCRIPTION
On fast machines the topology could get launched before the HTTP config server is fully up triggering 404s.
By moving the HTTP server code before launching the driver this should be prevented.

Thanks  Andrew Milkowski for reporting it!
